### PR TITLE
Add custom successful login check functionality

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -27,6 +27,7 @@ except ImportError: # django >= 1.7
 from axes.models import AccessLog
 from axes.models import AccessAttempt
 from axes.signals import user_locked_out
+from axes.utils import import_callable
 import axes
 from django.utils import six
 
@@ -309,11 +310,15 @@ def watch_login(func):
         if request.method == 'POST':
             # see if the login was successful
 
-            login_unsuccessful = (
-                response and
-                not response.has_header('location') and
-                response.status_code != 302
-            )
+            CUSTOM_UNSUCCESSFUL_LOGIN = getattr(settings, 'AXES_CUSTOM_UNSUCCESSFUL_LOGIN', None)
+            if CUSTOM_UNSUCCESSFUL_LOGIN is not None:
+                login_unsuccessful = import_callable(CUSTOM_UNSUCCESSFUL_LOGIN)(response)
+            else:
+                login_unsuccessful = (
+                    response and
+                    not response.has_header('location') and
+                    response.status_code != 302
+                )
 
             access_log = AccessLog.objects.create(
                 user_agent=request.META.get('HTTP_USER_AGENT', '<unknown>')[:255],

--- a/axes/tests.py
+++ b/axes/tests.py
@@ -15,6 +15,12 @@ from axes.signals import user_locked_out
 from axes.utils import reset
 
 
+def custom_unsuccessful_login(response):
+    """Use to test custom successful login functionality in settings
+    """
+    return True
+
+
 class AccessAttemptTest(TestCase):
     """Test case using custom settings for testing
     """
@@ -214,3 +220,10 @@ class AccessAttemptTest(TestCase):
         extra_data = {string.ascii_letters * x: x for x in range(0, 1000)}  # An impossibly large post dict
         self._login(**extra_data)
         self.assertEquals(len(AccessAttempt.objects.latest('id').post_data), 1024)
+
+    @override_settings(AXES_CUSTOM_UNSUCCESSFUL_LOGIN='axes.tests.custom_unsuccessful_login')
+    def test_custom_successful_login_function(self):
+        """Tests replacing default successful login check with custom one in settings
+        """
+        self._login(is_valid_username=True, is_valid_password=True)
+        self.assertFalse(AccessLog.objects.latest('id').trusted)

--- a/axes/utils.py
+++ b/axes/utils.py
@@ -1,3 +1,5 @@
+from importlib import import_module
+from six import string_types
 from axes.models import AccessAttempt
 
 
@@ -18,3 +20,12 @@ def reset(ip=None, username=None):
         attempts.delete()
 
     return count
+
+
+def import_callable(path_or_callable):
+    if hasattr(path_or_callable, '__call__'):
+        return path_or_callable
+    else:
+        assert isinstance(path_or_callable, string_types)
+        package, attr = path_or_callable.rsplit('.', 1)
+        return getattr(import_module(package), attr)


### PR DESCRIPTION
Previously there was just a single set of strict checks for the login
responses. This setting allows uses to create their own function to
check the response, meaning they can set whatever criteria they like.