### PR TITLE
Decorate auth_views.login only once

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -272,6 +272,10 @@ def watch_login(func):
     Used to decorate the django.contrib.admin.site.login method.
     """
 
+    # Don't decorate multiple times
+    if func.__name__ == 'decorated_login':
+        return func
+
     def decorated_login(request, *args, **kwargs):
         # share some useful information
         if func.__name__ != 'decorated_login' and VERBOSE:


### PR DESCRIPTION
During testing, the middleware is created (i.e. `__init__` is called) for every new request through the django test client. This PR adds a check, as suggested in #107, to not re-decorate `auth_views.login` over and over it if it's already been decorated.