### PR TITLE
Pull request for #88

### DIFF
--- a/axes/decorators.py
+++ b/axes/decorators.py
@@ -162,9 +162,10 @@ def query2str(items, max_length=1024):
 
     The length of the output is limited to max_length to avoid a DoS attack via excessively large payloads.
     """
-
-    return '\n'.join(['%s=%s' % (k, v) for k, v in six.iteritems(items)
-                      if k != PASSWORD_FORM_FIELD][:int(max_length/2)])[:max_length]
+    # Would rather not store any query data in plaintext
+    return ""
+    #return '\n'.join(['%s=%s' % (k, v) for k, v in six.iteritems(items)
+    #                  if k != PASSWORD_FORM_FIELD][:int(max_length/2)])[:max_length]
 
 
 def ip_in_whitelist(ip):


### PR DESCRIPTION
@camilonova asked me to pull request in #88 for the ipv4 and ipv6 validation changes, so here it is. However it comes with caveats.. the pull request includes more than ipv4 and ipv6 changes, and several of them are very opinionated. So please take a look and feel free to not take some things. 

Changes include:
1) Made several functions take a username behavior (I am handling my own login logic, so I felt more comfortable doing explicit checks than having a middleware intuit what checks should be made.)
2) Completely disabled all GET/POST data logging (For my own circumstances, I don't want the liability of storing potentially sensitive data.)
3) Removed REMOTE_ADDR sanitization (I'm doing this already in middleware)
4) Use django validation to check ipv4 and ipv6 validity
5) Removed the VERBOSE config param and changed to use python log levels

Also, I don't know what version of django introduced the ipv4/ipv6 validation functions. So it is possible that this change will break compatibility with older versions of django.

Only tested on python 3.4/django 1.9, and only in the ways that I am using the library. In particular, I'm only using the middleware with the built-in admin login page, and everywhere else I'm manually calling check_request/is_already_locked, passing in a username.