### PR TITLE
Add `default_app_config` so you can just use `axes` in `INSTALLED_APPS`

### DIFF
--- a/axes/__init__.py
+++ b/axes/__init__.py
@@ -1,5 +1,7 @@
 __version__ = '2.0.0'
 
+default_app_config = "axes.apps.AppConfig"
+
 
 def get_version():
     return __version__


### PR DESCRIPTION
By adding `default_app_config` to `__init__.py`, there is no need to change the `INSTALLED_APPS` entry when upgrading to axes 2.0. I think this would make life much easier for developers with many projects. - upgrading axes would involve just removing the middleware class.

It also ensures that the login view is always patched.